### PR TITLE
Adding vim.lineHighlightColorControl setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ Change the color of the status bar based on the current mode. Once enabled, conf
     "vim.statusBarColors.surroundinputmode": "#007ACC",
 ```
 
+Setting `"vim.lineHighlightColorControl": true` the current line in the editor will have same color than status bar. Only if `"vim.statusBarColorControl": true`.
+
 ### vim-easymotion
 
 Based on [vim-easymotion](https://github.com/easymotion/vim-easymotion) and configured through the following settings:

--- a/package.json
+++ b/package.json
@@ -651,6 +651,11 @@
           "markdownDescription": "Allow VSCodeVim to change status bar color based on mode. **NOTE:** Using this feature will have a negative impact on performance.",
           "default": false
         },
+        "vim.lineHighlightColorControl": {
+          "type": "boolean",
+          "markdownDescription": "Allow VSCodeVim to syncronize current line color based on mode. **NOTE:** vim.statusBarColorControl must be true.",
+          "default": false
+        },
         "vim.statusBarColors.normal": {
           "type": [
             "string",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -229,6 +229,8 @@ class Configuration implements IConfiguration {
 
   statusBarColorControl = false;
 
+  lineHighlightColorControl = false;
+
   statusBarColors: IModeSpecificStrings<string | string[]> = {
     normal: '#005f5f',
     insert: '#5f0000',

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -209,6 +209,11 @@ export interface IConfiguration {
   statusBarColorControl: boolean;
 
   /**
+   * Syncronize current line color based on mode.
+   */
+  lineHighlightColorControl: boolean;
+
+  /**
    * Status bar colors to change to based on mode
    */
   statusBarColors: IModeSpecificStrings<string | string[]>;

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -128,6 +128,10 @@ class StatusBarImpl implements vscode.Disposable {
       'statusBar.foreground': `${foreground}`,
     });
 
+    if (configuration.lineHighlightColorControl) {
+      colorCustomizations['editor.lineHighlightBackground'] = `${background}`;
+    }
+
     // If colors are undefined, return to VSCode defaults
     if (background === undefined) {
       delete colorCustomizations['statusBar.background'];

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -48,6 +48,7 @@ export class Configuration implements IConfiguration {
   incsearch = true;
   startInInsertMode = false;
   statusBarColorControl = false;
+  lineHighlightColorControl = false;
   statusBarColors: IModeSpecificStrings<string | string[]> = {
     normal: ['#8FBCBB', '#434C5E'],
     insert: '#BF616A',


### PR DESCRIPTION
## Created PR in original [VSCodeVim/Vim ](https://github.com/VSCodeVim/Vim)
https://github.com/VSCodeVim/Vim/pull/4761

Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [x] Commit messages has a short & issue references when necessary
- [x] Each commit does a logical chunk of work.
- [x] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
In VIM I use a different background color in the current line to know what is the VIM mode.

I would like include something similar in vscode. For instance in current line background color (setting in vscode: `editor.lineHighlightBackground`) we could use the same color than defined in `statusBarColorControl` options.

UI in vscode:
![vscode_line](https://user-images.githubusercontent.com/6368004/79882566-1cb2e880-83f3-11ea-8b5f-bbad5c8b932f.gif)


**Which issue(s) this PR fixes**
fixes https://github.com/VSCodeVim/Vim/issues/4760

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
