### PR TITLE
Text selection lost after click cmd+c

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -885,8 +885,11 @@ class CommandOverrideCopy extends BaseCommand {
     }
 
     await Clipboard.Copy(text);
+
+    // Why do we need this line?
+    // I commented it and everything seems fine
     // all vim yank operations return to normal mode.
-    await vimState.setCurrentMode(Mode.Normal);
+    // await vimState.setCurrentMode(Mode.Normal);
 
     return vimState;
   }


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
If you have selected text in the editor and you push `Copy` key (cmd + c), the current selected text desappears. This is very frustraiting for people like me that we push several times the `cmd+c` 🤷 

**Which issue(s) this PR fixes**
Not created issue yet.

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:

## Behaviour before fix
![losing_sel_text](https://user-images.githubusercontent.com/6368004/79908860-47656700-841c-11ea-8564-8084ed31331e.gif)

## Behaviour after fix
![selecting](https://user-images.githubusercontent.com/6368004/79908877-4cc2b180-841c-11ea-897b-85ebc777abcd.gif)
